### PR TITLE
Randomize TLS config name

### DIFF
--- a/pkg/clone/dbconfig.go
+++ b/pkg/clone/dbconfig.go
@@ -175,11 +175,12 @@ func (c DBConfig) openMySQL() (*sql.DB, error) {
 		return nil, errors.WithStack(err)
 	}
 	if tlsConfig != nil {
-		err = mysql.RegisterTLSConfig("cloner", tlsConfig)
+		tlsConfigName := fmt.Sprintf("cloner_%d", time.Now().UnixNano())
+		err = mysql.RegisterTLSConfig(tlsConfigName, tlsConfig)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
-		cfg.TLSConfig = "cloner"
+		cfg.TLSConfig = tlsConfigName
 	}
 	if c.Password != "" {
 		cfg.Passwd = c.Password


### PR DESCRIPTION
This has been a bug forever and I don't understand why we just hit it. Apparently the TLS configs of the source and target clobber each other if you use the same name. Silly API really.