### PR TITLE
We should use READ_COMMITTED for most things

### DIFF
--- a/pkg/clone/heartbeat.go
+++ b/pkg/clone/heartbeat.go
@@ -153,7 +153,7 @@ func (h *Heartbeat) createTable(ctx context.Context) error {
 func (h *Heartbeat) write(ctx context.Context) (int64, error) {
 	var count int64
 	err := Retry(ctx, h.sourceRetry, func(ctx context.Context) error {
-		return autotx.Transact(ctx, h.source, func(tx *sql.Tx) error {
+		return autotx.TransactWithOptions(ctx, h.source, &sql.TxOptions{Isolation: sql.LevelReadCommitted}, func(tx *sql.Tx) error {
 			_, err := tx.ExecContext(ctx, "SET time_zone = \"+00:00\"")
 			if err != nil {
 				return errors.WithStack(err)

--- a/pkg/clone/transactionwriter.go
+++ b/pkg/clone/transactionwriter.go
@@ -99,7 +99,7 @@ func (w *TransactionWriter) runSequential(ctx context.Context, b backoff.BackOff
 			return ctx.Err()
 		}
 
-		err := autotx.Transact(ctx, w.target, func(tx *sql.Tx) error {
+		err := autotx.TransactWithOptions(ctx, w.target, &sql.TxOptions{Isolation: sql.LevelReadCommitted}, func(tx *sql.Tx) error {
 			for _, mutation := range transaction.Mutations {
 				err := w.handleMutation(ctx, tx, mutation)
 				if err != nil {
@@ -312,7 +312,7 @@ func (s *transactionSequence) Run(ctx context.Context) error {
 		if len(transaction.transaction.Mutations) == 0 {
 			continue
 		}
-		err := autotx.Transact(ctx, s.writer.target, func(tx *sql.Tx) error {
+		err := autotx.TransactWithOptions(ctx, s.writer.target, &sql.TxOptions{Isolation: sql.LevelReadCommitted}, func(tx *sql.Tx) error {
 			for _, mutation := range transaction.transaction.Mutations {
 				err := s.writer.handleMutation(ctx, tx, mutation)
 				if err != nil {
@@ -479,7 +479,7 @@ func (w *TransactionWriter) runParallel(ctx context.Context, b backoff.BackOff, 
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			err = autotx.Transact(ctx, w.target, func(tx *sql.Tx) error {
+			err = autotx.TransactWithOptions(ctx, w.target, &sql.TxOptions{Isolation: sql.LevelReadCommitted}, func(tx *sql.Tx) error {
 				err := w.writeCheckpoint(ctx, tx, currentlyExecutingTransactionSet.finalPosition)
 				return errors.WithStack(err)
 			})

--- a/pkg/clone/writer.go
+++ b/pkg/clone/writer.go
@@ -357,7 +357,7 @@ func (w *Writer) writeBatch(ctx context.Context, batch Batch) (err error) {
 		retry.Timeout = timout
 	}
 	err = Retry(ctx, retry, func(ctx context.Context) error {
-		err = autotx.Transact(ctx, w.db, func(tx *sql.Tx) error {
+		err = autotx.TransactWithOptions(ctx, w.db, &sql.TxOptions{Isolation: sql.LevelReadCommitted}, func(tx *sql.Tx) error {
 			timer := prometheus.NewTimer(writeDuration.WithLabelValues(batch.Table.Name, string(batch.Type)))
 			defer timer.ObserveDuration()
 			defer func() {


### PR DESCRIPTION
READ_COMMITTED should be fine because while the default (REPEATABLE_READ) protects against a few read anomalies we take great care in cloner to make sure there are no concurrent writes to the same data. the only reads we do out of the target database is when we diff a chunk before we repair it but that should never be concurrent with any other writes to the same chunk.