### PR TITLE
Retry at the transaction level

### DIFF
--- a/test/load/main.go
+++ b/test/load/main.go
@@ -133,7 +133,6 @@ func main() {
 				"--ignore-tables", "history",
 				"--failed-chunk-retry-count", "10",
 				"--read-retries", "10",
-				"--repair-attempts", "10",
 			)
 			repairingChecksum.Stdout = os.Stdout
 			repairingChecksum.Stderr = OnFirstOutput(os.Stderr, "no diffs found", func() {


### PR DESCRIPTION
Instead of restarting the entire replication thread after a failure
