### PR TITLE
remove the default value, to allow pass in starting gtid

### DIFF
--- a/pkg/clone/replicate.go
+++ b/pkg/clone/replicate.go
@@ -120,7 +120,7 @@ type Replicate struct {
 	ParallelTransactionBatchMaxSize int           `help:"How large batch of transactions to parallelize" default:"100"`
 	ParallelTransactionBatchTimeout time.Duration `help:"How long to wait for a batch of transactions to fill up before executing them anyway" default:"5s"`
 	StartingGTID                    string        `help:"When starting a new replication this GTID set as the starting point" xor:"starting_gtid"`
-	StartAtLastSourceGTID           bool          `help:"When starting a new replication use the value of the 'target_gtid' of the source checkpoint table" default:"false" xor:"starting_gtid"`
+	StartAtLastSourceGTID           bool          `help:"When starting a new replication use the value of the 'target_gtid' of the source checkpoint table" xor:"starting_gtid"`
 }
 
 // Run replicates from source to target


### PR DESCRIPTION
Having `default:"false"` will make the argument always present, which disallow passing in StartingGTID, because they belong to the same xor group.
And it will default to false anyway