### PR TITLE
add logging to debug heart beat issue

### DIFF
--- a/pkg/clone/heartbeat.go
+++ b/pkg/clone/heartbeat.go
@@ -94,6 +94,7 @@ func (h *Heartbeat) Run(ctx context.Context, b backoff.BackOff) error {
 			writeTime := time.Now().UTC()
 			count, err := h.write(ctx)
 			if err != nil {
+				logrus.Errorf("error writing a heart beat: %v", err)
 				return errors.WithStack(err)
 			}
 
@@ -172,6 +173,7 @@ func (h *Heartbeat) createTable(ctx context.Context) error {
 func (h *Heartbeat) write(ctx context.Context) (int64, error) {
 	var count int64
 	err := Retry(ctx, h.sourceRetry, func(ctx context.Context) error {
+		logrus.Infof("write a heart beat to source database")
 		return autotx.TransactWithOptions(ctx, h.source, &sql.TxOptions{Isolation: sql.LevelReadCommitted}, func(tx *sql.Tx) error {
 			_, err := tx.ExecContext(ctx, "SET time_zone = \"+00:00\"")
 			if err != nil {


### PR DESCRIPTION
In cloud database (which is the source for reverse replication), the timestamp and count has not been updated since 01:51 (now it's 21:30)

```
mysql> select * from _cloner_heartbeat;
+------+---------------------+--------+
| task | time                | count  |
+------+---------------------+--------+
| main | 2023-07-10 01:51:11 | 219202 |
+------+---------------------+--------+
```